### PR TITLE
Make repository a go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/akamensky/base58
+
+go 1.15


### PR DESCRIPTION
Go modules make using the code easier by not requiring the repo to be cloned into GOPATH, for example.